### PR TITLE
Feat/restapi options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@
 ## Feature
 
 - **A variety of ways :** You can set HTTP methods, test duration, requests per second, ports, and so on.
-- **Simple to run, but powerful. :** Test with a command in a single line of cli and show various analysis data.
+- **Simple to run, but powerful. :** Test with simple json and a command in a single line of cli. It will be show various analysis data.
 
 ## How to use
 
@@ -29,28 +29,51 @@
 - System requirement
   - Singijeon runs on Windows, linux, macos with most recent LTS release of Node.js / NPM.
 
-### Run your first test
-
-- Enter the command below in cli
-  ```
-  singijeon
-  ```
-
 ### How to use
 
-- You can run this cli application through the command
-  ```
-  singijeon
-  ```
-- Steps
+- 1. Prepare a json file with the information you want to use for the test.
+     Based on the type you want to test, make a json file according to the items below
 
-  1. Choose HTTP Protocol
+  - REST API
+    |Key|Value Type|Description|Example|Required|
+    |------|---|---|---|---|
+    |method|string|all of http method(get,post,put,patch,delete etc)|"POST"|True|
+    |url|string|endpoint url to send request|Example|True|
+    |port|number|port number (443/80 is default on https/http)|Example|False|
+    |duration|number|How long will it be tested|10|True|
+    |rate|number|How many requests per second|3|True|
+    |header|object|HTTP Header| {"Content-type": "application/json; charset=UTF-8"}|False|
+    |body|object|HTTP Body|{"title": "foo","body": "bar","userId": 1}|False|
 
-  2. Depending on the HTTP Protocol, enter or select the information to proceed with the test.
+    - example
 
-  - If you have selected REST API, you need to input/select the information below.
-    - Endpoint URL
-    - duration
-    - rate
-    - method
-    - port
+    ```
+    //data.json
+
+      {
+        "method": "POST",
+        "url": "https://jsonplaceholder.typicode.com/posts",
+        "port": 443,
+        "duration": 3,
+        "rate": 1,
+        "header": {
+          "Content-type": "application/json; charset=UTF-8"
+        },
+        "body": {
+          "title": "foo",
+          "body": "bar",
+          "userId": 1
+        }
+      }
+    ```
+
+- 2. Enter the command below in cli
+     ```
+     singijeon
+     ```
+
+- 3. Select the api protocols you want to test
+
+- 4. Select the json file created in the first step.
+
+  // If you don't know how to write a json file for test, you can refer to the example in the examples directory in this repository.

--- a/examples/command.sh
+++ b/examples/command.sh
@@ -1,0 +1,1 @@
+singijeon

--- a/examples/test-samples/rest-get.json
+++ b/examples/test-samples/rest-get.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.google.com",
+  "duration": 5,
+  "rate": 1,
+  "method": "GET"
+}

--- a/examples/test-samples/rest-post.json
+++ b/examples/test-samples/rest-post.json
@@ -1,0 +1,15 @@
+{
+  "method": "POST",
+  "url": "https://jsonplaceholder.typicode.com/posts",
+  "port": 443,
+  "duration": 3,
+  "rate": 1,
+  "header": {
+    "Content-type": "application/json; charset=UTF-8"
+  },
+  "body": {
+    "title": "foo",
+    "body": "bar",
+    "userId": 1
+  }
+}

--- a/lib/core.js
+++ b/lib/core.js
@@ -3,7 +3,15 @@ import https from "https";
 import ProgressBar from "progress";
 import { getAverage, getMedian } from "./util.js";
 
-export async function sendHttpRequests(url, method, port, duration, rate) {
+export async function sendHttpRequests(
+  url,
+  method,
+  port,
+  duration,
+  rate,
+  header,
+  body
+) {
   const interval = 1000 / rate;
   const startTime = Date.now();
   const endTime = startTime + duration * 1000;
@@ -15,12 +23,15 @@ export async function sendHttpRequests(url, method, port, duration, rate) {
   const requestUrl = new URL(url);
   const requestOptions = {
     method: method ? method.toUpperCase() : "GET",
+    headers: header,
+    body: body,
     port: port
       ? port.toString()
       : requestUrl.protocol === "https:"
       ? "443"
       : "80",
   };
+
   let requestSuccessCount = 0; //요청 성공 횟수
   let requestErrorCount = 0; //요청 실패 횟수
   let responseSpeed = []; //응답 속도
@@ -59,7 +70,6 @@ export async function sendHttpRequests(url, method, port, duration, rate) {
 
     const req = client.request(url, requestOptions, (res) => {
       // 요청 성공 처리
-
       let requestEndDate = Date.now();
       responseSpeed.push(requestEndDate - reqeustStartDate);
       ++requestSuccessCount;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "singijeon",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "singijeon",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.3.8",
-        "commander": "^12.1.0",
         "inquirer": "^10.1.7",
         "inquirer-file-selector": "^0.3.1",
         "progress": "^2.0.3"
@@ -346,15 +345,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "singijeon",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "singijeon",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@inquirer/prompts": "^5.3.8",
         "commander": "^12.1.0",
         "inquirer": "^10.1.7",
+        "inquirer-file-selector": "^0.3.1",
         "progress": "^2.0.3"
       },
       "bin": {
@@ -289,6 +290,18 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -388,6 +401,20 @@
         "mute-stream": "^1.0.0",
         "run-async": "^3.0.0",
         "rxjs": "^7.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer-file-selector": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer-file-selector/-/inquirer-file-selector-0.3.1.tgz",
+      "integrity": "sha512-n2F4YzuDbkMa84LFBe5o01C++QOWAuL5+MvDNcldqmZXLbL0aIKZY0tQsXmN/XcTdsqFkARlcEvLVFp4MNFoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.10",
+        "@inquirer/figures": "^1.0.5",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "main": "index.js",
   "dependencies": {
     "@inquirer/prompts": "^5.3.8",
-    "commander": "^12.1.0",
     "inquirer": "^10.1.7",
     "inquirer-file-selector": "^0.3.1",
     "progress": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "singijeon": "./index.js"
   },
   "type": "module",
-  "preferGlobal": true
+  "preferGlobal": true,
+  "homepage": "https://singijeon.com/"
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@inquirer/prompts": "^5.3.8",
     "commander": "^12.1.0",
     "inquirer": "^10.1.7",
+    "inquirer-file-selector": "^0.3.1",
     "progress": "^2.0.3"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "singijeon",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Easy, Simple, Fast Load Testing Tool",
   "keywords": [
     "load testing",


### PR DESCRIPTION
## Feature
- The part where you enter information about the test has been changed from cli to json file. Now we only select api protocol, and we only use interactive cli to select json files.

   reason : In order to put the header and body setting function in the rest api, and considering the graphql and gRPC to be supported later, there was a limit to the method of using only the current cli. Therefore, in order to expand the test more, we made it more flexible to receive related test information through the json file.

- You can now set the header and body in the request information in restapi. 

    reason : Other methods except 'get' generally require body when request. In line with the flow of these APIs, body and header are should be supported.

- Add examples of the json file where I put the test information. This examples makes it easier for first-timers to see how to organize the json file.